### PR TITLE
Allow Sa::Members.profile_create to pass along a hashed password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.3] - 2017-03-13
+### Fixed
+- Allow YourMembership::Sa::Members.profile_create to pass along
+  a hashed password when one is present.
+
 ## [1.1.2] - 2017-02-16
 ### Added
 - Allow httparty v0.14.x

--- a/lib/your_membership/sa_members.rb
+++ b/lib/your_membership/sa_members.rb
@@ -172,7 +172,8 @@ module YourMembership
         YourMembership::Sa::Auth.authenticate(
           YourMembership::Session.create,
           profile.data['Username'],
-          profile.data['Password']
+          profile.data['Password'],
+          profile.data['PasswordHash']
         )
       end
     end

--- a/lib/your_membership/version.rb
+++ b/lib/your_membership/version.rb
@@ -1,3 +1,3 @@
 module YourMembership
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end


### PR DESCRIPTION
This non-breaking change allows the YourMembership::Sa::Members.profile_create method to pass along a hashed password when one is available in the supplied profile.