### PR TITLE
Handle HTTParty response.body = nil

### DIFF
--- a/lib/httparty/patch.rb
+++ b/lib/httparty/patch.rb
@@ -23,7 +23,7 @@ module HTTParty
     def fix_cdata(body)
       # <![CDATA[ = &lt;![CDATA[
       # ]]> =  ]]&gt;
-      if body.include? '&lt;![CDATA['
+      if body.present? && body.include? '&lt;![CDATA['
         body.gsub! '&lt;![CDATA[', '<![CDATA['
         body.gsub! ']]&gt', ']]>'
       end

--- a/lib/httparty/patch.rb
+++ b/lib/httparty/patch.rb
@@ -23,7 +23,7 @@ module HTTParty
     def fix_cdata(body)
       # <![CDATA[ = &lt;![CDATA[
       # ]]> =  ]]&gt;
-      if body.present? && body.include? '&lt;![CDATA['
+      if body.present? && body.include?('&lt;![CDATA[')
         body.gsub! '&lt;![CDATA[', '<![CDATA['
         body.gsub! ']]&gt', ']]>'
       end

--- a/lib/httparty/patch.rb
+++ b/lib/httparty/patch.rb
@@ -23,7 +23,7 @@ module HTTParty
     def fix_cdata(body)
       # <![CDATA[ = &lt;![CDATA[
       # ]]> =  ]]&gt;
-      if body.present? && body.include?('&lt;![CDATA[')
+      if !body.nil? && body.include?('&lt;![CDATA[')
         body.gsub! '&lt;![CDATA[', '<![CDATA['
         body.gsub! ']]&gt', ']]>'
       end

--- a/spec/fixtures/vcr_cassettes/no_body_response.yml
+++ b/spec/fixtures/vcr_cassettes/no_body_response.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.yourmembership.com/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <YourMembership>
+          <Version>2.00</Version>
+          <ApiKey><PRIVATE_KEY></ApiKey>
+          <SaPasscode><SA_PASSCODE></SaPasscode>
+          <CallID>10000</CallID>
+          <Call Method="Sa.Members.All.GetIDs">
+            <Timestamp>2015-12-02 15:54:11</Timestamp>
+          </Call>
+        </YourMembership>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '24051'
+      Content-Type:
+      - text/xml; Charset=utf-8
+      Set-Cookie:
+      - "<ASP_SESSION_ID>"
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 16 Dec 2015 20:54:12 GMT
+      Connection:
+      - Keep-alive
+    body:
+      string: null
+    http_version:
+  recorded_at: Wed, 16 Dec 2015 20:54:12 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_cassettes/sa_members_cdata.yml
+++ b/spec/fixtures/vcr_cassettes/sa_members_cdata.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.yourmembership.com/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <YourMembership>
+          <Version>2.00</Version>
+          <ApiKey><PRIVATE_KEY></ApiKey>
+          <SaPasscode><SA_PASSCODE></SaPasscode>
+          <CallID>10000</CallID>
+          <Call Method="Sa.Members.All.GetIDs">
+            <Timestamp>2015-12-02 15:54:11</Timestamp>
+          </Call>
+        </YourMembership>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '24051'
+      Content-Type:
+      - text/xml; Charset=utf-8
+      Set-Cookie:
+      - "<ASP_SESSION_ID>"
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 16 Dec 2015 20:54:12 GMT
+      Connection:
+      - Keep-alive
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n\r\n<YourMembership_Response>\r\n<ErrCode>0</ErrCode>\r\n<ExtendedErrorInfo>&lt;![CDATA[Text information here]]&gt;</ExtendedErrorInfo>\r\n<Sa.Members.All.GetIDs>\r\n<ServerGmtBias>-5</ServerGmtBias>\r\n<ServerTime>2015-12-16
+        15:54:12</ServerTime>\r\n<Members>\r\n<ID>57EEB598-CB44-4D85-B0D6-377F393AF5B4</ID>\r\n<ID>1C0CE647-FAA5-4EB0-ADF0-5B669B36378E</ID>\r\n</Members>\r\n</Sa.Members.All.GetIDs>\r\n</YourMembership_Response>\r\n"
+    http_version:
+  recorded_at: Wed, 16 Dec 2015 20:54:12 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_cassettes/sa_members_no_body.yml
+++ b/spec/fixtures/vcr_cassettes/sa_members_no_body.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.yourmembership.com/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/xml; Charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Server:
+      - Microsoft-IIS/8.5
+      Set-Cookie:
+      - "<ASP_SESSION_ID>"
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Thu, 17 Aug 2017 20:18:09 GMT
+      Content-Length:
+      - '301'
+    body:
+      encoding: ASCII-8BIT
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n\r\n<YourMembership_Response>\r\n<ErrCode>902</ErrCode>\r\n<ExtendedErrorInfo></ExtendedErrorInfo>\r\n<ErrDesc>XML
+        packet is malformed or otherwise unreadable.</ErrDesc>\r\n<XmlRequest>\r\n<unnamed></unnamed>\r\n</XmlRequest>\r\n</YourMembership_Response>\r\n"
+    http_version: 
+  recorded_at: Thu, 17 Aug 2017 20:18:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/httparty/patch_spec.rb
+++ b/spec/lib/httparty/patch_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'FixCdata' do
+  it 'string returned' do
+    VCR.use_cassette 'sa_members_all_getids_timestamp_single' do
+      response = HTTParty.post("https://api.yourmembership.com/")
+      expect(response.body).to be_a(String)
+    end
+  end
+
+  it 'replace &lt;![CDATA' do
+    VCR.use_cassette 'sa_members_cdata' do
+      response = HTTParty.post("https://api.yourmembership.com/")
+      expect(response.body).to include("<![CDATA[")
+    end
+  end
+
+  it 'replace ]]&gt' do
+    VCR.use_cassette 'sa_members_cdata' do
+      response = HTTParty.post("https://api.yourmembership.com/")
+      expect(response.body).to include("]]>")
+    end
+  end
+
+  it 'handle blank body response' do
+    VCR.use_cassette 'no_body_response' do
+      # Note that a nil body is unlikely (never) to occur within YM, but other non-YM tools may respond with a nil body
+      response = HTTParty.post("https://api.yourmembership.com/")
+      expect(response.body).to be nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'dotenv'
 require 'pry'
 require 'vcr'
 require 'your_membership'
+require 'webmock/rspec'
 
 Dotenv.load(
   File.expand_path('../../.env.local', __FILE__),
@@ -98,4 +99,3 @@ YourMembership.configure(
   privateKey: ENV.fetch('YM_API_PRIVATE_KEY'),
   saPasscode: ENV.fetch('YM_API_SA_PASSCODE')
 )
-


### PR DESCRIPTION
An odd edge case unrelated to Your Membership, but was affected by the HTTParty patch as part of this gem.

Working with another provider API, when processing a HTTParty.delete(...) request, the API returns a nil body.  The `fix_cdata` patch doesn't handle nil gracefully and fails.

This pull request fixes that patch by simply adding `if !body.nil? && ...`
Also created specs for the existing method functionality and the newly added functionality.

This helps me immensely, and will hopefully help someone else too!