### PR TITLE
Support httparty 0.21 gem

### DIFF
--- a/your_membership.gemspec
+++ b/your_membership.gemspec
@@ -21,7 +21,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", ">=0.13.1", "<0.19"
+  # This gem will work with 2.3.0 due to the httparty required gem
+  spec.required_ruby_version = '>= 2.3.0'
+
+  spec.add_dependency "httparty", ">=0.13.1", "<0.21"
   spec.add_dependency "nokogiri", "~>1.6"
 
   spec.add_development_dependency "bundler", "<3"

--- a/your_membership.gemspec
+++ b/your_membership.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # This gem will work with 2.3.0 due to the httparty required gem
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "httparty", ">=0.13.1", "<0.21"
+  spec.add_dependency "httparty", ">=0.13.1", "<=0.21"
   spec.add_dependency "nokogiri", "~>1.6"
 
   spec.add_development_dependency "bundler", "<3"


### PR DESCRIPTION
HTTParty gem <= 0.20.0 has a moderate severity vulnerability [GHSA-5pq7-52mg-hr42](https://github.com/advisories/GHSA-5pq7-52mg-hr42) identified. I don't believe this directly affects the YM gem, but should be upgradable to ensure vulnerable gems aren't used in projects.

Unfortunately, upgrading to httparty gem 0.21.0 requires Ruby >= 2.3.  Recommend merging this as a major version since it may introduce a breaking change.  But since Ruby 2.3 ended 4.5 years ago, hopefully it will be a minor impact to most YM gem users.

There are no other breaking changes in the httparty gem upgrade based on their [Changelog](https://github.com/jnunemaker/httparty/blob/master/Changelog.md)

Thanks!